### PR TITLE
feat(theming): create theme toggle button

### DIFF
--- a/src/components/ThemeToggle/ThemeToggle.css.ts
+++ b/src/components/ThemeToggle/ThemeToggle.css.ts
@@ -1,0 +1,27 @@
+import { style } from "@vanilla-extract/css";
+
+export const toggleButton = style({
+  padding: "0.5rem 1rem",
+  border: "1px solid #ccc",
+  borderRadius: "4px",
+  background: "transparent",
+  color: "inherit",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+  transition: "background-color 0.2s ease, border-color 0.2s ease",
+  selectors: {
+    '&:hover': {
+      backgroundColor: "#f0f0f0",
+    },
+    '&:focus': {
+      outline: "2px solid #4f46e5",
+      outlineOffset: "2px",
+    },
+    '[data-theme="dark"] &': {
+      borderColor: "#555",
+      '&:hover': {
+        backgroundColor: "#222",
+      },
+    },
+  },
+});

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -2,15 +2,16 @@ import { useEffect, useState } from "react";
 import { lightTheme, darkTheme } from "../../styles/theme.css";
 import { toggleButton } from "./ThemeToggle.css";
 
-type ThemeMode = "light" | "dark" | "system";
+const THEME_STORAGE_KEY = "theme";
 
+type ThemeMode = "light" | "dark" | "system";
 function getSystemTheme(): "light" | "dark" {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
 export function ThemeToggle() {
   const [theme, setTheme] = useState<ThemeMode>(() => {
-    const saved = localStorage.getItem("theme") as ThemeMode | null;
+    const saved = localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode | null;
     return saved ?? "system";
   });
 

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -29,8 +29,13 @@ export function ThemeToggle() {
     if (theme === "system") {
       const media = window.matchMedia("(prefers-color-scheme: dark)");
       const listener = () => applyTheme("system");
-      media.addEventListener("change", listener);
-      return () => media.removeEventListener("change", listener);
+      if (media.addEventListener) {
+        media.addEventListener("change", listener);
+        return () => media.removeEventListener("change", listener);
+      } else if (media.addListener) {
+        media.addListener(listener);
+        return () => media.removeListener(listener);
+      }
     }
   }, [theme]);
 

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { lightTheme, darkTheme } from "../../styles/theme.css";
+import { toggleButton } from "./ThemeToggle.css";
+
+type ThemeMode = "light" | "dark" | "system";
+
+function getSystemTheme(): "light" | "dark" {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<ThemeMode>(() => {
+    const saved = localStorage.getItem("theme") as ThemeMode | null;
+    return saved ?? "system";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const applyTheme = (mode: ThemeMode) => {
+      root.classList.remove(lightTheme, darkTheme);
+      const effective = mode === "system" ? getSystemTheme() : mode;
+      root.classList.add(effective === "dark" ? darkTheme : lightTheme);
+    };
+
+    applyTheme(theme);
+
+    if (theme === "system") {
+      const media = window.matchMedia("(prefers-color-scheme: dark)");
+      const listener = () => applyTheme("system");
+      media.addEventListener("change", listener);
+      return () => media.removeEventListener("change", listener);
+    }
+  }, [theme]);
+
+  const cycleTheme = () => {
+    const order: ThemeMode[] = ["light", "dark", "system"];
+    const next = order[(order.indexOf(theme) + 1) % order.length];
+    setTheme(next);
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <button
+      onClick={cycleTheme}
+      aria-label="Toggle theme mode"
+      className={toggleButton}
+    >
+      {theme === "system"
+        ? "🖥️ System"
+        : theme === "dark"
+        ? "🌙 Dark"
+        : "☀️ Light"}
+    </button>
+  );
+}

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -44,7 +44,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={cycleTheme}
-      aria-label="Toggle theme mode"
+      aria-label={`Toggle theme mode, current mode: ${theme === "system" ? "System" : theme === "dark" ? "Dark" : "Light"}`}
       className={toggleButton}
     >
       {theme === "system"


### PR DESCRIPTION
This pull request introduces a new `ThemeToggle` component, allowing users to switch between light, dark, and system themes. It includes both the component's functionality and its associated styles. Below are the key changes:

### New `ThemeToggle` Component:

* **Component Implementation (`src/components/ThemeToggle/ThemeToggle.tsx`)**:
  - Added a `ThemeToggle` component with a button to cycle through "light," "dark," and "system" themes.
  - Implemented theme detection based on system preferences using `window.matchMedia`.
  - Persisted the selected theme in `localStorage` and applied it to the `document.documentElement` class list.

### Styling for `ThemeToggle`:

* **CSS Styling (`src/components/ThemeToggle/ThemeToggle.css.ts`)**:
  - Defined styles for the toggle button, including padding, border, hover effects, and dark mode-specific adjustments.
  - Added transitions for smooth visual feedback on hover and focus states.